### PR TITLE
ignores error 409

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ MANIFEST
 Lib/
 Scripts/
 doc/
+fwdevelop/
 
 # Test otuput
 mca/test_output

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -1,6 +1,10 @@
 """
 MVG library
 -----------
+For use of client side development the MVG class shall be used.
+
+The MVGAPI class is intended for development of the library itself.
+
 For more information see README.md.
 """
 
@@ -704,16 +708,17 @@ class MVGAPI:
 
 class MVG(MVGAPI):
     """Class for a session providing an API to the vibium server.
-    Subclass to MVGAPI adding convience functions
-    - waiting for request
-    - ignoring http errors (per default 409, existing resource)
+    Note that this class ignores specific http errors
+    (per default 409, existing resource). If this is not wanted use
+    MVGAPI class instead.
     """
 
     def __init__(self, endpoint: str, token: str):
         """
         Constructor.
-        As compared to super class configures session to ignore '
-        409 error. More errors can be ignored by setting class
+        As compared to super class configures session to ignore
+        409 errors (occuring when an existing resource is overwritten.
+        More errors can be ignored by setting class
         attribute do_not_raise with a dictionary of http error codes.
         On instantiation of a MVG object the session parameters
         are stored for future calls and the version of the API
@@ -722,6 +727,7 @@ class MVG(MVGAPI):
         valid token from testcases.
         HTTPError is raised if  a connection to the API cannot
         be established.
+
         Parameters
         ----------
         endpoint: str
@@ -734,6 +740,7 @@ class MVG(MVGAPI):
 
     def wait_for_analyses(self, jobid_list: list, timeout=None):
         """Wait for the analyses specified by list of jobids to finish.
+
         Parameters
         ----------
         jobid_list : list

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -45,8 +45,8 @@ class MVGAPI:
 
         self.endpoint = endpoint
         self.token = token
-
-        self.mvg_version = self.parse_version("v0.4.1")
+        
+        self.mvg_version = self.parse_version("v0.5.0")
         self.tested_api_version = self.parse_version("v0.1.1")
 
         # Errors to ignore

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -45,7 +45,7 @@ class MVGAPI:
 
         self.endpoint = endpoint
         self.token = token
-        
+
         self.mvg_version = self.parse_version("v0.5.0")
         self.tested_api_version = self.parse_version("v0.1.1")
 

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -47,7 +47,7 @@ class MVGAPI:
         self.token = token
 
         self.mvg_version = self.parse_version("v0.4.1")
-        self.tested_api_version = self.parse_version("v0.1.0")
+        self.tested_api_version = self.parse_version("v0.1.1")
 
         # Errors to ignore
         self.do_not_raise = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import requests
 
-VIBIUM_VERSION = "v0.0.9"
+VIBIUM_VERSION = "v0.1.1"
 
 
 def is_responsive(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,11 @@ import os
 
 import pytest
 import requests
+from mvg import MVG
 
-VIBIUM_VERSION = "v0.1.1"
+# Retrieve API version to test against
+session = MVG("NO ENDPOINT", "NO TOKEN")
+VIBIUM_VERSION = "v" + str(session.tested_api_version)
 
 
 def is_responsive(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import requests
 from mvg import MVG
 
 # Retrieve API version to test against
-session = MVG("NO ENDPOINT", "NO TOKEN")
-VIBIUM_VERSION = "v" + str(session.tested_api_version)
+version_session = MVG("https://api.beta.multiviz.com", "NO TOKEN")
+VIBIUM_VERSION = "v" + str(version_session.tested_api_version)
 
 
 def is_responsive(url):

--- a/tests/test_api_general.py
+++ b/tests/test_api_general.py
@@ -68,10 +68,7 @@ def test_supported_features(vibium):
     session = MVG(vibium, VALID_TOKEN)
     resp = session.supported_features()
     print(resp)
-    assert resp["mode_id"]
-    # assert not resp['on_off']
-    # assert not resp['asset_type']
-    assert not resp["indicator_arrow"]
+    assert resp["ModeId"]
 
 
 # API GET    /analyses [unauthorized]


### PR DESCRIPTION
- Allows to specify a list of http errors to be ignored
- Ignores 409 errors
- steps API Version to be tested against
- API version to be tested against will now be fetched from MVG class
