### PR TITLE
API should only return measurements without data for each measurement

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -395,8 +395,8 @@ class MVGAPI:
         self._request("post", f"/sources/{sid}/measurements", json=meas_struct)
 
     # in example
-    def read_measurements(self, sid: str):
-        """Retrieves all measurements (all timestamps) for a source.
+    def list_measurements(self, sid: str):
+        """Retrieves all measurements (all timestamps and metadata) for a source.
 
         Parameters
         ----------

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -396,7 +396,7 @@ class MVGAPI:
 
     # in example
     def read_measurements(self, sid: str):
-        """Retrieves all measurements for all timestamps for a source.
+        """Retrieves all measurements (all timestamps) for a source.
 
         Parameters
         ----------
@@ -412,16 +412,9 @@ class MVGAPI:
         logger.info("retrieving all measurements from source id=%s", sid)
 
         response = self._request("get", f"/sources/{sid}/measurements")
+        all_measurements = response.json()
 
-        # Step 2: read actual measurement data for all timestamps
-        timestamps = response.json()
-        logger.info("%s measurements in database", len(timestamps))
-
-        all_measurements = []
-        for m_time in timestamps:
-            all_measurements.append(
-                self.read_single_measurement(sid, m_time["timestamp"])
-            )
+        logger.info("%s measurements in database", len(all_measurements))
 
         return all_measurements
 

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -164,7 +164,7 @@ def test_measurements_crud(session):
         session.delete_measurement(SOURCE_ID, ts_m)
 
     # check if empty
-    m_left = session.read_measurements(SOURCE_ID)
+    m_left = session.list_measurements(SOURCE_ID)
     assert len(m_left) == 0
 
 


### PR DESCRIPTION
### Summary
- Closes #17 
- Removed code that retrieves data for each measurement
- Fixed the API description a bit
- Verified the test cases that use the API `read_measurements`

TODO: Update the example ipynbs in the docs folder