### PR TITLE
Adds command line option for running tests as integration test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,19 +10,21 @@ import sys
 
 # This version of conftest.py adds some really ugly code to
 # run the tests as integration tests by running like
-# >pytest -s  tests --host http://127.0.0.1:8000
+# > pytest -s  tests --host http://127.0.0.1:8000
 # As it is impossible to call a fixture outside a test
 # and I did not find a way to disable docker compose
 # the command line argument --host is consumed by argparse
 # before being passed to pytest
 # see https://izziswift.com/how-to-pass-arguments-in-pytest-by-command-line/
 
+
+# Stuff for --host
 # needed, otherwise --host will fail pytest
 def pytest_addoption(parser):
     parser.addoption("--host")
 
 
-# ugly parser code
+# consume --host via argparse
 parser = argparse.ArgumentParser(description="run test on --host")
 parser.add_argument(
     "--host", help="host to run tests on (default: %(default)s)", default=""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,33 @@ import pytest
 import requests
 from mvg import MVG
 
+
+import argparse
+import sys
+
+# This version of conftest.py adds some really ugly code to
+# run the tests as integration tests by running like
+# >pytest -s  tests --host http://127.0.0.1:8000
+# As it is impossible to call a fixture outside a test
+# and I did not find a way to disable docker compose
+# the command line argument --host is consumed by argparse
+# before being passed to pytest
+# see https://izziswift.com/how-to-pass-arguments-in-pytest-by-command-line/
+
+# needed otherwhise --host will fail pytest
+def pytest_addoption(parser):
+    parser.addoption("--host")   
+
+# ugly parser code
+parser = argparse.ArgumentParser(description="run test on --host")
+parser.add_argument('--host', help='host to run tests on (default: %(default)s)', default="")
+args, notknownargs = parser.parse_known_args()
+sys.argv[1:] = notknownargs
+
+
 # Retrieve API version to test against
 version_session = MVG("https://api.beta.multiviz.com", "NO TOKEN")
 VIBIUM_VERSION = "v" + str(version_session.tested_api_version)
-
 
 def is_responsive(url):
     try:
@@ -23,15 +46,26 @@ def docker_compose_file(pytestconfig):
     os.environ["VIBIUM_VERSION"] = VIBIUM_VERSION
     return pytestconfig.rootdir / "tests" / "docker-compose.yml"
 
+# ugly vibium fixture configuration
+# Here we need to switch between vibium fixture
+# for docker-run (--host not set)
+# or for run towards a running server
+# e.g. --host http://127.0.0.1:8000
+if args.host == "":
+    @pytest.fixture(scope="session")
+    def vibium(docker_ip, docker_services, target_url):
+        """Ensure that HTTP service is up and responsive."""
+        # `port_for` takes a container port and returns the corresponding host port
+        port = docker_services.port_for("vibium", 8000)
+        url = "http://{}:{}".format(docker_ip, port)
+        docker_services.wait_until_responsive(
+            timeout=30.0, pause=0.1, check=lambda: is_responsive(url)
+        )
+        return url
 
-@pytest.fixture(scope="session")
-def vibium(docker_ip, docker_services):
-    """Ensure that HTTP service is up and responsive."""
-
-    # `port_for` takes a container port and returns the corresponding host port
-    port = docker_services.port_for("vibium", 8000)
-    url = "http://{}:{}".format(docker_ip, port)
-    docker_services.wait_until_responsive(
-        timeout=30.0, pause=0.1, check=lambda: is_responsive(url)
-    )
-    return url
+else:
+    @pytest.fixture(scope="session")
+    # ugly function fetching golbal argument inside context
+    def vibium():
+        """Ensure that HTTP service is up and responsive."""
+        return args.host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,16 @@ import sys
 # before being passed to pytest
 # see https://izziswift.com/how-to-pass-arguments-in-pytest-by-command-line/
 
-# needed otherwhise --host will fail pytest
+# needed, otherwise --host will fail pytest
 def pytest_addoption(parser):
-    parser.addoption("--host")   
+    parser.addoption("--host")
+
 
 # ugly parser code
 parser = argparse.ArgumentParser(description="run test on --host")
-parser.add_argument('--host', help='host to run tests on (default: %(default)s)', default="")
+parser.add_argument(
+    "--host", help="host to run tests on (default: %(default)s)", default=""
+)
 args, notknownargs = parser.parse_known_args()
 sys.argv[1:] = notknownargs
 
@@ -31,6 +34,7 @@ sys.argv[1:] = notknownargs
 # Retrieve API version to test against
 version_session = MVG("https://api.beta.multiviz.com", "NO TOKEN")
 VIBIUM_VERSION = "v" + str(version_session.tested_api_version)
+
 
 def is_responsive(url):
     try:
@@ -46,12 +50,14 @@ def docker_compose_file(pytestconfig):
     os.environ["VIBIUM_VERSION"] = VIBIUM_VERSION
     return pytestconfig.rootdir / "tests" / "docker-compose.yml"
 
+
 # ugly vibium fixture configuration
 # Here we need to switch between vibium fixture
 # for docker-run (--host not set)
 # or for run towards a running server
 # e.g. --host http://127.0.0.1:8000
 if args.host == "":
+
     @pytest.fixture(scope="session")
     def vibium(docker_ip, docker_services, target_url):
         """Ensure that HTTP service is up and responsive."""
@@ -63,7 +69,9 @@ if args.host == "":
         )
         return url
 
+
 else:
+
     @pytest.fixture(scope="session")
     # ugly function fetching golbal argument inside context
     def vibium():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ def docker_compose_file(pytestconfig):
 if args.host == "":
 
     @pytest.fixture(scope="session")
-    def vibium(docker_ip, docker_services, target_url):
+    def vibium(docker_ip, docker_services):
         """Ensure that HTTP service is up and responsive."""
         # `port_for` takes a container port and returns the corresponding host port
         port = docker_services.port_for("vibium", 8000)

--- a/tests/test_api_general.py
+++ b/tests/test_api_general.py
@@ -12,16 +12,6 @@ from mvg import MVG
 
 VALID_TOKEN = os.environ["TEST_TOKEN"]
 
-
-# To override vibium with a locally running version
-# @pytest.fixture(scope="session")
-# def vibium():
-#     # url = "http://127.0.0.1:8000"
-#     url = "https://api.beta.multiviz.com"
-#     print(f"Overriding vibium function with url {url}")
-#     return url
-
-
 # API        /
 def test_say_hello(vibium):
     session = MVG(vibium, "NO TOKEN")

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -23,14 +23,6 @@ REF_DB_PATH = Path.cwd() / "tests" / "test_data" / "mini_charlie"
 SOURCE_ID = uuid.uuid1().hex  # generate a unique source per testrun
 
 
-# To override vibium with a locally running version
-# @pytest.fixture(scope="session")
-# def vibium():
-#     url = "https://api.beta.multiviz.com"
-#     # url = "http://127.0.0.1:8000"
-#     return url
-
-
 @pytest.fixture(scope="session")
 def session(vibium):
 


### PR DESCRIPTION
This PR add some really ugly code to conftest.py to allow
running the tests as integration tests by running like
```
>pytest -s  tests --host http://127.0.0.1:8000
```
see [here](https://izziswift.com/how-to-pass-arguments-in-pytest-by-command-line/) for a motivation why it may actually require an ugly solution
