### PR TITLE
Fix for #54

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -412,7 +412,6 @@ class MVGAPI:
         # Package info for db to be submitted
         meas_struct = [
             {
-                "source_id": sid,  # should be source_id
                 "timestamp": timestamp,
                 "duration": duration,
                 "data": data,


### PR DESCRIPTION
### What does this PR fix?
closes #54 

### Problem
Incompatibility between the backend model requirements and the data fed from MVG API

### Solution
`create_measurement` in MVG API should not call the backend with extra fields (e.g. source_id) in the API payload

### Why did this problem occur?
Commit https://github.com/vikinganalytics/vibium-cloud/pull/271 in Vibium introduced a new model `BaseModelForbidExtra` which prevents extra fields in the payload.

