### PR TITLE
Specify package_dir in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vikinganalytics/mvg",
+    package_dir={"": "mvg"},
     packages=setuptools.find_packages(where="mvg"),
     license="LICENSE",
     classifiers=[


### PR DESCRIPTION
`package_dir` needs to be specified in `setup.py`. The [build fails](https://github.com/vikinganalytics/mvg/actions/runs/1181364382) otherwise.