### PR TITLE
fix included modules in the installation

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -51,7 +51,7 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.7.8")
+        self.mvg_version = self.parse_version("v0.7.9")
         self.tested_api_version = self.parse_version("v0.1.15")
 
         # Get API version

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vikinganalytics/mvg",
-    package_dir={"": "mvg"},
-    packages=setuptools.find_packages(where="mvg"),
+    package_dir={"": "."},
+    packages=setuptools.find_packages(where=".", include=["mvg", "mvg.*"]),
     license="LICENSE",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
When using `package_dir` in `setup.py`, that folder itself will not be considered a module and only submodules contained in it will be considered. In previous commit (see #64), module `mvg` was not available after the installation rather a module called `features` was available. This PR changes the source directory to root and specifies the name of included packages and subpackages separately.