### PR TITLE
add python 3.10 to CI worksflow

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -53,7 +53,7 @@ jobs:
         needs: [black, pylint, flake8]
         strategy:
             matrix:
-              python-version: [3.6,3.7,3.8,3.9]
+              python-version: [3.6,3.7,3.8,3.9,"3.10"]
         steps: 
         -   uses: actions/checkout@v2
         -   name: "Set up Python ${{ matrix.python-version }}"


### PR DESCRIPTION
python 3.10 was released on October 4th. Time to add it to the list