### PR TITLE
Included selected_channels and selected_columns in request analysis method signature

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -671,6 +671,8 @@ class MVGAPI:
         sid: str,
         feature: str,
         parameters: dict = None,
+        selected_channels: List[str] = None,
+        selected_columns: List[str] = None,
         start_timestamp: int = None,
         end_timestamp: int = None,
         callback_url: str = None,
@@ -687,6 +689,14 @@ class MVGAPI:
 
         parameters : dict
             name value pairs of parameters [optional].
+
+        selected_channels : List[str]
+            Subset of Waveform Data channels for analysis.
+            Empty list means selection of all available channels [optional].
+
+        selected_columns : List[str]
+            Subset of Tabular Data columns for analysis.
+            Empty list means selection of all available columns [optional].
 
         start_timestamp : int
             start of analysis time window [optional].
@@ -712,6 +722,14 @@ class MVGAPI:
 
         if parameters is None:
             parameters = dict()
+
+        # Update parameters with certain method parameters
+        parameters.update(
+            {
+                "selected_channels": selected_channels or [],
+                "selected_columns": selected_columns or [],
+            }
+        )
 
         # Package info for db to be submitted
         analysis_info = {

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -53,8 +53,8 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.10.1")
-        self.tested_api_version = self.parse_version("v0.2.7")
+        self.mvg_version = self.parse_version("v0.10.2")
+        self.tested_api_version = self.parse_version("v0.2.8")
 
         # Get API version
         try:

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -692,11 +692,11 @@ class MVGAPI:
 
         selected_channels : List[str]
             Subset of Waveform Data channels for analysis.
-            Empty list means selection of all available channels [optional].
+            This cannot be used in conjuction with selected_columns [optional].
 
         selected_columns : List[str]
             Subset of Tabular Data columns for analysis.
-            Empty list means selection of all available columns [optional].
+            This cannot be used in conjuction with selected_channels [optional].
 
         start_timestamp : int
             start of analysis time window [optional].
@@ -724,12 +724,10 @@ class MVGAPI:
             parameters = dict()
 
         # Update parameters with certain method parameters
-        parameters.update(
-            {
-                "selected_channels": selected_channels or [],
-                "selected_columns": selected_columns or [],
-            }
-        )
+        if selected_channels:
+            parameters["selected_channels"] = selected_channels
+        if selected_columns:
+            parameters["selected_columns"] = selected_columns
 
         # Package info for db to be submitted
         analysis_info = {
@@ -753,6 +751,8 @@ class MVGAPI:
         sids: List[str],
         feature: str,
         parameters: dict = None,
+        selected_channels: List[str] = None,
+        selected_columns: List[str] = None,
         start_timestamp: int = None,
         end_timestamp: int = None,
         callback_url: str = None,
@@ -769,6 +769,14 @@ class MVGAPI:
 
         parameters : dict
             name value pairs of parameters [optional].
+
+        selected_channels : List[str]
+            Subset of Waveform Data channels for analysis.
+            This cannot be used in conjuction with selected_columns [optional].
+
+        selected_columns : List[str]
+            Subset of Tabular Data columns for analysis.
+            This cannot be used in conjuction with selected_channels [optional].
 
         start_timestamp : int
             start of analysis time window [optional].
@@ -794,6 +802,12 @@ class MVGAPI:
 
         if parameters is None:
             parameters = dict()
+
+        # Update parameters with certain method parameters
+        if selected_channels:
+            parameters["selected_channels"] = selected_channels
+        if selected_columns:
+            parameters["selected_columns"] = selected_columns
 
         # Package info for db to be submitted
         analysis_info = {


### PR DESCRIPTION
### Checklist
- [x] Update mvg version
- [x] Update backend version

### What does the PR close?
closes #97 

### What does the PR solve/fix/add?
- Earlier, `request_analysis` and `request_population_analysis` method allowed passing `selected_channels` and `selected_columns` as keys inside the `parameters` dictionary. Now, new method parameters `selected_channels` and `selected_columns` have been added to both the methods, which can be used to perform the same capability as before.
- Note: `selected_channels` and `selected_columns` can still be injected into the parameters dictionary, but if the method arguments are given a valid value (other than None or []), the latter will be given preference 

### Test cases
None
