### PR TITLE
Adding mode probabilities to modeid class

### DIFF
--- a/mvg/features/modeid.py
+++ b/mvg/features/modeid.py
@@ -28,7 +28,9 @@ class ModeId(Analysis):
         else:
             dict_for_df = self.results().copy()
             dict_for_emerging = dict_for_df.pop("mode_info")
+            dict_for_mode_proba = dict_for_df.pop("", {})
             self.emerging_df = pd.DataFrame.from_dict(dict_for_emerging)
+            self.probabilities = pd.DataFrame.from_dict(dict_for_mode_proba)
             self._results_df = pd.DataFrame.from_dict(dict_for_df)
             self._add_datetime()
             self.emerging_df = self._add_datetime_df(self.emerging_df, "emerging_time")

--- a/mvg/features/modeid.py
+++ b/mvg/features/modeid.py
@@ -28,7 +28,7 @@ class ModeId(Analysis):
         else:
             dict_for_df = self.results().copy()
             dict_for_emerging = dict_for_df.pop("mode_info")
-            dict_for_mode_proba = dict_for_df.pop("", {})
+            dict_for_mode_proba = dict_for_df.pop("mode_probabilities", {})
             self.emerging_df = pd.DataFrame.from_dict(dict_for_emerging)
             self.probabilities = pd.DataFrame.from_dict(dict_for_mode_proba)
             self._results_df = pd.DataFrame.from_dict(dict_for_df)

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -53,7 +53,7 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.10.3")
+        self.mvg_version = self.parse_version("v0.10.4")
         self.tested_api_version = self.parse_version("v0.2.9")
 
         # Get API version


### PR DESCRIPTION
Fixing bug when using new version of vibium with probability table. If there is no probability table the results will be an empty dataframe

closes #107 