### PR TITLE
Pytest conftest refactor and test cases for selected channels and selected columns

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -770,14 +770,6 @@ class MVGAPI:
         parameters : dict
             name value pairs of parameters [optional].
 
-        selected_channels : List[str]
-            Subset of Waveform Data channels for analysis.
-            This cannot be used in conjuction with selected_columns [optional].
-
-        selected_columns : List[str]
-            Subset of Tabular Data columns for analysis.
-            This cannot be used in conjuction with selected_channels [optional].
-
         start_timestamp : int
             start of analysis time window [optional].
 
@@ -802,12 +794,6 @@ class MVGAPI:
 
         if parameters is None:
             parameters = dict()
-
-        # Update parameters with certain method parameters
-        if selected_channels:
-            parameters["selected_channels"] = selected_channels
-        if selected_columns:
-            parameters["selected_columns"] = selected_columns
 
         # Package info for db to be submitted
         analysis_info = {

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -751,8 +751,6 @@ class MVGAPI:
         sids: List[str],
         feature: str,
         parameters: dict = None,
-        selected_channels: List[str] = None,
-        selected_columns: List[str] = None,
         start_timestamp: int = None,
         end_timestamp: int = None,
         callback_url: str = None,

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -53,7 +53,7 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.10.4")
+        self.mvg_version = self.parse_version("v0.10.5")
         self.tested_api_version = self.parse_version("v0.2.9")
 
         # Get API version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,8 @@ def pytest_configure():
     pytest.SOURCE_ID_WAVEFORM = uuid.uuid1().hex
     pytest.REF_DB_PATH = Path.cwd() / "tests" / "test_data" / "mini_charlie"
     pytest.SOURCE_ID_TABULAR = uuid.uuid1().hex
-    pytest.VALID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2MjA4MDg2NTMsImV4cCI6MTY1MjM5OTEwMCwiY2xpZW50X2lkIjoidmEiLCJzaXRlX2lkIjoidmlzaG51In0.eOCT-UbAf3sXLTgGwzCT75NeXbw5J2Sy0MSuZpZXltQfyLj3NzDfCOJR6k4fdZKhSCYcgLbEuSng8CNyjlGyYfzzZcVdgoye13n0X6lBP6Xti8ePvLHUPGxoNiBV0eTSVzK5gIMp3k7RCAEKdlBqUXy-nnx1SY_1VAv86rIiqV0"
+    pytest.VALID_TOKEN = os.environ["TEST_TOKEN"]
+
 
 def is_responsive(url):
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,11 @@ import argparse
 import sys
 from requests import HTTPError
 
-from tests.helpers import generate_sources_patterns, stub_multiaxial_data, upload_measurements
+from tests.helpers import (
+    generate_sources_patterns,
+    stub_multiaxial_data,
+    upload_measurements,
+)
 
 # This version of conftest.py adds some really ugly code to
 # run the tests as integration tests by running like
@@ -188,14 +192,15 @@ def waveform_source_with_measurements(session, waveform_source):
 
     yield waveform_source
 
+
 def waveform_source_multiaxial_fixture_creator(source_id, pattern):
     @pytest.fixture
     def fixture(session):
         try:
             timestamps, data, _ = stub_multiaxial_data(pattern=pattern)
             session.create_source(
-            source_id, meta={"type": "pump"}, channels=list(pattern.keys())
-        )
+                source_id, meta={"type": "pump"}, channels=list(pattern.keys())
+            )
             upload_measurements(session, source_id, data)
             yield source_id, timestamps
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,7 +193,9 @@ def waveform_source_with_measurements(session, waveform_source):
 def waveform_source_multiaxial(session):
     source_id = "multiaxial_source_001"
     try:
-        session.create_source(source_id, meta={"type": "pump"}, channels=["acc_x", "acc_y", "acc_z"])
+        session.create_source(
+            source_id, meta={"type": "pump"}, channels=["acc_x", "acc_y", "acc_z"]
+        )
         yield source_id
     finally:
         session.delete_source(source_id)
@@ -202,7 +204,11 @@ def waveform_source_multiaxial(session):
 @pytest.fixture
 def waveform_source_multiaxial_with_measurements(session, waveform_source_multiaxial):
     source_id = waveform_source_multiaxial
-    pattern = {"acc_x": [0] * 13 + [1] * 7, "acc_y": [0] * 6 + [1] * 14, "acc_z": [0] * 13 + [1] * 7}
+    pattern = {
+        "acc_x": [0] * 13 + [1] * 7,
+        "acc_y": [0] * 6 + [1] * 14,
+        "acc_z": [0] * 13 + [1] * 7,
+    }
     timestamps, data, _ = stub_multiaxial_data(pattern=pattern)
     upload_measurements(session, source_id, data)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,12 +3,15 @@ from itertools import cycle
 
 from mvg.mvg import MVG
 
+
 def upload_measurements(session: MVG, sid: str, data: list):
     """Upload measurements for a source"""
     timestamps = list(data.keys())
     for ts in timestamps:
         ts_data = data[ts]
-        session.create_measurement(sid, ts_data["meta"]["duration"], ts, ts_data["data"], ts_data["meta"])
+        session.create_measurement(
+            sid, ts_data["meta"]["duration"], ts, ts_data["data"], ts_data["meta"]
+        )
 
 
 def stub_multiaxial_data(samp_freq=3000, duration=3.0, pattern={}):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,83 @@
+import numpy as np
+from itertools import cycle
+
+from mvg.mvg import MVG
+
+def upload_measurements(session: MVG, sid: str, data: list):
+    """Upload measurements for a source"""
+    timestamps = list(data.keys())
+    for ts in timestamps:
+        ts_data = data[ts]
+        session.create_measurement(sid, ts_data["meta"]["duration"], ts, ts_data["data"], ts_data["meta"])
+
+
+def stub_multiaxial_data(samp_freq=3000, duration=3.0, pattern={}):
+    """Create measurements based on cosine signals (with added noise) for a multiaxial source.
+
+    Parameters
+    ----------
+    samp_freq
+        Sampling frequency of the signal
+    duration
+        Duration of each measurement
+    pattern
+        Dictionary of axis with each axis pointing to a list of patterns. Length of every pattern must be equal.
+
+    Returns
+    -------
+    timestamps
+        List of timestamps, one for each measurement
+    data
+        Dictionary of timestamps, with each timestamp pointing to a dictionary containing measurements for each axis and metadata
+    duration
+        Duration of the measurements
+
+    Examples
+    --------
+    >>> pattern = {'acc_x': [0] * 1 + [1] * 1, 'acc_x': [0] * 2, 'acc_z': [1] * 2}
+    >>> timestamps, data, duration = stub_multiaxial_data()
+    >>> print(data)
+    {0: {"data": {"acc_x": [...], "acc_y": [...], "acc_z": [...]}, "meta": {}}, 3600000: {"data": {"acc_x": [...], "acc_y": [...], "acc_z": [...]}, "meta": {}}}
+    """
+
+    # Collect list of axis and number of measurements from pattern
+    axes = list(pattern.keys())
+    assert len(axes) > 0 and len(axes) <= 3
+    n_meas = len(list(pattern.values())[0])
+    assert all(len(p) == n_meas for p in pattern.values())
+
+    timestamps = [k * 3600 * 1000 for k in range(n_meas)]
+    n_samples = int(samp_freq * duration)
+    T = np.linspace(0.0, duration, n_samples + 1)
+    f_peak = 300.0
+    np.random.seed(0)
+
+    # Find unique modes from the pattern
+    unique_modes = set()
+    for value_list in list(pattern.values()):
+        unique_modes.update(value_list)
+
+    # Define signal for each unique mode
+    signals = []
+    for k in unique_modes:
+        signals.append(np.cos(2 * np.pi * (f_peak + (k * 200)) * T))
+
+    # Generate data dict
+    # Iterate through a zip of (timestamp, list of axis, list of pattern for the timestamp)
+    data = {}
+    pattern_by_meas = zip(*pattern.values())
+    for timestamp, axes_list, ptn_list in zip(
+        timestamps, cycle([axes]), pattern_by_meas
+    ):
+        data[timestamp] = {
+            "data": {
+                axis: list(signals[ptn] + np.random.normal(0, 0.05, len(T)))
+                for (axis, ptn) in zip(axes_list, ptn_list)
+            },
+            "meta": {
+                "duration": duration,
+                "sampling_rate": samp_freq,
+            },
+        }
+
+    return timestamps, data, duration

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -84,3 +84,17 @@ def stub_multiaxial_data(samp_freq=3000, duration=3.0, pattern={}):
         }
 
     return timestamps, data, duration
+
+def generate_sources_patterns():
+    """Generate a list of multiaxial sources with axis-based patterns"""
+    sources_patterns = [
+        (
+            "multiaxial_source_001",
+            {
+                "acc_x": [0] * 6 + [1] * 14 + [0] * 5,
+                "acc_y": [0] * 6 + [1] * 14 + [0] * 5,
+                "acc_z": [0] * 6 + [1] * 14 + [0] * 5,
+            },
+        )
+    ]
+    return sources_patterns

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -85,6 +85,7 @@ def stub_multiaxial_data(samp_freq=3000, duration=3.0, pattern={}):
 
     return timestamps, data, duration
 
+
 def generate_sources_patterns():
     """Generate a list of multiaxial sources with axis-based patterns"""
     sources_patterns = [

--- a/tests/test_api_analyses.py
+++ b/tests/test_api_analyses.py
@@ -112,9 +112,7 @@ def test_modeid_analysis_selected_columns(session, tabular_source_with_measureme
     assert_results(None)
 
 
-def test_modeid_analysis_selected_channels(
-    session, waveform_source_multiaxial_001
-):
+def test_modeid_analysis_selected_channels(session, waveform_source_multiaxial_001):
     source_id, _ = waveform_source_multiaxial_001
     source_info = session.get_source(source_id)
     channels = source_info["properties"]["channels"]

--- a/tests/test_api_analyses.py
+++ b/tests/test_api_analyses.py
@@ -91,3 +91,40 @@ def test_callback_server_failure(
     )
     session.wait_for_analyses([req["request_id"]])
     assert "400 Bad Request" in LOG_FILE.read_text()
+
+def test_modeid_analysis_selected_columns(session, tabular_source_with_measurements):
+    source_id, tabular_dict = tabular_source_with_measurements
+    columns = list(tabular_dict.keys())
+
+    # Test with defined selected_columns
+    selected_columns = columns[1:3]
+    req = session.request_analysis(source_id, "ModeId", selected_columns=selected_columns)
+    session.wait_for_analyses([req["request_id"]])
+    results = session.get_analysis_results(req["request_id"])
+    assert results["inputs"]["selected_columns"] == selected_columns
+
+    # Test with undefined selected_columns
+    selected_columns = None
+    req = session.request_analysis(source_id, "ModeId", selected_columns=selected_columns)
+    session.wait_for_analyses([req["request_id"]])
+    results = session.get_analysis_results(req["request_id"])
+    assert results["inputs"]["selected_columns"] == []
+
+def test_modeid_analysis_selected_channels(session, waveform_source_multiaxial_with_measurements):
+    source_id, _ = waveform_source_multiaxial_with_measurements
+    source_info = session.get_source(source_id)
+    channels = source_info["properties"]["channels"]
+
+    # Test with defined selected_channels
+    selected_channels = channels[:2]
+    req = session.request_analysis(source_id, "ModeId", selected_channels=selected_channels)
+    session.wait_for_analyses([req["request_id"]])
+    results = session.get_analysis_results(req["request_id"])
+    assert results["inputs"]["selected_channels"] == selected_channels
+
+    # Test with undefined selected_channels
+    selected_channels = None
+    req = session.request_analysis(source_id, "ModeId", selected_channels=selected_channels)
+    session.wait_for_analyses([req["request_id"]])
+    results = session.get_analysis_results(req["request_id"])
+    assert results["inputs"]["selected_channels"] == []

--- a/tests/test_api_analyses.py
+++ b/tests/test_api_analyses.py
@@ -92,39 +92,43 @@ def test_callback_server_failure(
     session.wait_for_analyses([req["request_id"]])
     assert "400 Bad Request" in LOG_FILE.read_text()
 
+
 def test_modeid_analysis_selected_columns(session, tabular_source_with_measurements):
     source_id, tabular_dict = tabular_source_with_measurements
     columns = list(tabular_dict.keys())
 
+    def assert_results(selected_columns):
+        req = session.request_analysis(
+            source_id, "ModeId", selected_columns=selected_columns
+        )
+        session.wait_for_analyses([req["request_id"]])
+        results = session.get_analysis_results(req["request_id"])
+        assert results["inputs"]["selected_columns"] == (selected_columns or [])
+
     # Test with defined selected_columns
-    selected_columns = columns[1:3]
-    req = session.request_analysis(source_id, "ModeId", selected_columns=selected_columns)
-    session.wait_for_analyses([req["request_id"]])
-    results = session.get_analysis_results(req["request_id"])
-    assert results["inputs"]["selected_columns"] == selected_columns
+    assert_results(columns[1:3])
 
-    # Test with undefined selected_columns
-    selected_columns = None
-    req = session.request_analysis(source_id, "ModeId", selected_columns=selected_columns)
-    session.wait_for_analyses([req["request_id"]])
-    results = session.get_analysis_results(req["request_id"])
-    assert results["inputs"]["selected_columns"] == []
+    # Test with defined selected_columns
+    assert_results(None)
 
-def test_modeid_analysis_selected_channels(session, waveform_source_multiaxial_with_measurements):
+
+def test_modeid_analysis_selected_channels(
+    session, waveform_source_multiaxial_with_measurements
+):
     source_id, _ = waveform_source_multiaxial_with_measurements
     source_info = session.get_source(source_id)
     channels = source_info["properties"]["channels"]
 
-    # Test with defined selected_channels
-    selected_channels = channels[:2]
-    req = session.request_analysis(source_id, "ModeId", selected_channels=selected_channels)
-    session.wait_for_analyses([req["request_id"]])
-    results = session.get_analysis_results(req["request_id"])
-    assert results["inputs"]["selected_channels"] == selected_channels
+    def assert_results(selected_channels):
+        req = session.request_analysis(
+            source_id, "ModeId", selected_channels=selected_channels
+        )
+        session.wait_for_analyses([req["request_id"]])
+        results = session.get_analysis_results(req["request_id"])
+        assert results["inputs"]["selected_channels"] == (selected_channels or [])
 
-    # Test with undefined selected_channels
-    selected_channels = None
-    req = session.request_analysis(source_id, "ModeId", selected_channels=selected_channels)
-    session.wait_for_analyses([req["request_id"]])
-    results = session.get_analysis_results(req["request_id"])
-    assert results["inputs"]["selected_channels"] == []
+    # Test with defined selected_channels
+    assert_results(channels[:2])
+
+    # Test with defined selected_channels
+    assert_results(None)

--- a/tests/test_api_analyses.py
+++ b/tests/test_api_analyses.py
@@ -113,9 +113,9 @@ def test_modeid_analysis_selected_columns(session, tabular_source_with_measureme
 
 
 def test_modeid_analysis_selected_channels(
-    session, waveform_source_multiaxial_with_measurements
+    session, waveform_source_multiaxial_001
 ):
-    source_id, _ = waveform_source_multiaxial_with_measurements
+    source_id, _ = waveform_source_multiaxial_001
     source_info = session.get_source(source_id)
     channels = source_info["properties"]["channels"]
 

--- a/tests/test_api_general.py
+++ b/tests/test_api_general.py
@@ -11,8 +11,8 @@ from requests import HTTPError
 import requests
 from mvg import MVG
 
-VALID_TOKEN = os.environ["TEST_TOKEN"]
-
+# MVG Token
+VALID_TOKEN = pytest.VALID_TOKEN
 
 # API        /
 def test_say_hello(vibium):

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -7,44 +7,12 @@ Tests need to be run in order
 -p no:randomly
 """
 from datetime import datetime, timedelta
-from pathlib import Path
-
 import os
 import json
-import uuid
+import numpy as np
 import pandas as pd
 from requests import HTTPError
 import pytest
-import numpy as np
-
-# Test data and session setup
-REF_DB_PATH = Path.cwd() / "tests" / "test_data" / "mini_charlie"
-SOURCE_ID_WAVEFORM = uuid.uuid1().hex  # generate a unique source per test
-
-SOURCE_ID_TABULAR = uuid.uuid1().hex
-
-tabular_df = pd.read_csv(
-    REF_DB_PATH.parent / "tabular_data.csv", float_precision="round_trip"
-)
-tabular_dict = tabular_df.to_dict("list")
-
-
-@pytest.fixture()
-def tabular_source(session):
-    try:
-        columns = tabular_df.columns.tolist()
-        meta = {"extra": "information"}
-        session.create_tabular_source(SOURCE_ID_TABULAR, meta, columns)
-        yield SOURCE_ID_TABULAR
-    finally:
-        session.delete_source(SOURCE_ID_TABULAR)
-
-
-@pytest.fixture()
-def tabular_source_with_measurements(session, tabular_source):
-    session.create_tabular_measurement(SOURCE_ID_TABULAR, tabular_dict)
-    yield tabular_source
-
 
 # Just to check if API is live
 def test_say_hello(session):
@@ -62,21 +30,22 @@ def test_say_hello(session):
 # API GET    /sources/{source_id}
 # API PUT    /sources/{source_id}
 def test_sources_cru(session):
-    m_file_name = REF_DB_PATH / "u0001" / "meta.json"
+    source = pytest.SOURCE_ID_WAVEFORM
+    m_file_name = pytest.REF_DB_PATH / "u0001" / "meta.json"
     with open(m_file_name, "r") as json_file:
         meta = json.load(json_file)
     # create_source happy case
-    session.create_source(SOURCE_ID_WAVEFORM, meta=meta, channels=["acc"])
+    session.create_source(source, meta=meta, channels=["acc"])
     # list_source happy case
-    src = session.get_source(SOURCE_ID_WAVEFORM)
-    assert src["source_id"] == SOURCE_ID_WAVEFORM
+    src = session.get_source(source)
+    assert src["source_id"] == source
     assert src["meta"] == meta
 
     # update source
     meta["updated"] = "YES!"
-    session.update_source(SOURCE_ID_WAVEFORM, meta)
-    src = session.get_source(SOURCE_ID_WAVEFORM)
-    assert src["source_id"] == SOURCE_ID_WAVEFORM
+    session.update_source(source, meta)
+    src = session.get_source(source)
+    assert src["source_id"] == source
     assert src["meta"] == meta
 
 
@@ -84,7 +53,7 @@ def test_sources_cru(session):
 def test_list_sources(session):
     sources = session.list_sources()
     print(sources)
-    assert False in [SOURCE_ID_WAVEFORM != s["source_id"] for s in sources]
+    assert False in [pytest.SOURCE_ID_WAVEFORM != s["source_id"] for s in sources]
 
 
 # API GET    /sources/{source_id}/measurements
@@ -93,9 +62,9 @@ def test_list_sources(session):
 # API PUT    /sources/{source_id}/measurements/{timestamp}
 # API DELETE /sources/{source_id}/measurements/{timestamp}
 def test_measurements_crud(session):
-
+    source = pytest.SOURCE_ID_WAVEFORM
     # get list of measurements
-    src_path = REF_DB_PATH / "u0001"
+    src_path = pytest.REF_DB_PATH / "u0001"
     meas = {f.split(".")[0] for f in os.listdir(src_path)}
     meas.remove("meta")
     meas = [int(m) for m in meas]
@@ -106,7 +75,7 @@ def test_measurements_crud(session):
 
         # samples file for one measurement
         ts_meas = str(ts_m) + ".csv"  # filename
-        ts_meas = REF_DB_PATH / "u0001" / ts_meas  # path to file
+        ts_meas = src_path / ts_meas  # path to file
         ts_df = pd.read_csv(
             ts_meas, names=["acc"], float_precision="round_trip"
         )  # read csv into df
@@ -115,7 +84,7 @@ def test_measurements_crud(session):
 
         # meta information file for one measurement
         ts_meta = str(ts_m) + ".json"  # filename
-        ts_meta = REF_DB_PATH / "u0001" / ts_meta  # path
+        ts_meta = src_path / ts_meta  # path
         with open(ts_meta, "r") as json_file:  # read json
             meas_info = json.load(json_file)  # into dict
             print(f"Read meta:{meas_info}")
@@ -129,7 +98,7 @@ def test_measurements_crud(session):
 
         # create
         session.create_measurement(
-            sid=SOURCE_ID_WAVEFORM,
+            sid=source,
             duration=duration,
             timestamp=ts_m,
             data={"acc": accs},
@@ -138,7 +107,7 @@ def test_measurements_crud(session):
 
         # create again (ignore error)
         session.create_measurement(
-            sid=SOURCE_ID_WAVEFORM,
+            sid=source,
             duration=duration,
             timestamp=ts_m,
             data={"acc": accs},
@@ -147,26 +116,26 @@ def test_measurements_crud(session):
         )
 
         # read back and check
-        m_back = session.read_single_measurement(SOURCE_ID_WAVEFORM, ts_m)
+        m_back = session.read_single_measurement(source, ts_m)
         assert m_back["data"] == {"acc": accs}
         assert m_back["meta"] == meta_info
         assert m_back["duration"] == duration
 
         # update
         meta_info["updated"] = "YES!"
-        session.update_measurement(SOURCE_ID_WAVEFORM, ts_m, meta_info)
+        session.update_measurement(source, ts_m, meta_info)
 
         # read back and check
-        m_back = session.read_single_measurement(SOURCE_ID_WAVEFORM, ts_m)
+        m_back = session.read_single_measurement(source, ts_m)
         assert m_back["data"] == {"acc": accs}
         assert m_back["meta"] == meta_info
         assert m_back["duration"] == duration
 
         # delete
-        session.delete_measurement(SOURCE_ID_WAVEFORM, ts_m)
+        session.delete_measurement(source, ts_m)
 
     # check if empty
-    m_left = session.list_measurements(SOURCE_ID_WAVEFORM)
+    m_left = session.list_measurements(source)
     assert len(m_left) == 0
 
 
@@ -185,7 +154,7 @@ def test_failure_create_measurement(session):
 def test_failure_get_measurement(session):
 
     with pytest.raises(HTTPError) as exc:
-        session.delete_measurement(SOURCE_ID_WAVEFORM, 314152)
+        session.delete_measurement(pytest.SOURCE_ID_WAVEFORM, 314152)
 
     assert exc.value.response.status_code == 404
 
@@ -219,9 +188,9 @@ def test_failure_create_source(session):
 # API DELETE /sources/{source_id}
 def test_sources_d(session):
 
-    session.delete_source(SOURCE_ID_WAVEFORM)
+    session.delete_source(pytest.SOURCE_ID_WAVEFORM)
     with pytest.raises(HTTPError) as exc:
-        session.get_source(sid=SOURCE_ID_WAVEFORM)
+        session.get_source(sid=pytest.SOURCE_ID_WAVEFORM)
 
     assert exc.value.response.status_code == 404
     print("Finishing")
@@ -234,84 +203,95 @@ def test_sources_d(session):
 # API POST   /sources/{source_id} - source exists, ignored
 # API POST   /sources/{source_id} - source exists, not ignored
 def test_sources_cru_existing(session):
-    m_file_name = REF_DB_PATH / "u0001" / "meta.json"
+    source = pytest.SOURCE_ID_WAVEFORM
+    m_file_name = pytest.REF_DB_PATH / "u0001" / "meta.json"
     with open(m_file_name, "r") as json_file:
         meta = json.load(json_file)
     # create_source happy case
-    session.create_source(SOURCE_ID_WAVEFORM, meta=meta, channels=["acc"])
+    session.create_source(source, meta=meta, channels=["acc"])
     # list_source happy case
-    src = session.get_source(SOURCE_ID_WAVEFORM)
-    assert src["source_id"] == SOURCE_ID_WAVEFORM
+    src = session.get_source(source)
+    assert src["source_id"] == source
     assert src["meta"] == meta
 
     # create_source again (409 ignored)
     session.create_source(
-        SOURCE_ID_WAVEFORM, meta=meta, channels=["acc"], exist_ok=True
+        source, meta=meta, channels=["acc"], exist_ok=True
     )
 
     # create_source again (409 not ignored)
     with pytest.raises(HTTPError):
-        session.create_source(SOURCE_ID_WAVEFORM, meta=meta, channels=["acc"])
+        session.create_source(source, meta=meta, channels=["acc"])
 
 
 def test_tabular_sources(session, tabular_source):
-    columns = tabular_df.columns.tolist()
+    source_id, tabular_dict = tabular_source
+    columns = list(tabular_dict.keys())
     meta = {"extra": "information"}
 
     # create source again (409 ignored)
-    session.create_tabular_source(tabular_source, meta, columns, exist_ok=True)
+    session.create_tabular_source(source_id, meta, columns, exist_ok=True)
 
     # create source again (409 not ignored)
     with pytest.raises(HTTPError) as exc:
-        session.create_tabular_source(tabular_source, meta, columns)
+        session.create_tabular_source(source_id, meta, columns)
     assert exc.value.response.status_code == 409
 
     columns.remove("timestamp")
-    src = session.get_source(tabular_source)
-    assert src["source_id"] == tabular_source
+    src = session.get_source(source_id)
+    assert src["source_id"] == source_id
     assert src["meta"] == meta
     assert src["properties"]["columns"] == columns
 
 
 def test_tabular_measurements_float_timestamps(session, tabular_source):
     with pytest.raises(HTTPError) as exc:
+        source_id, tabular_dict = tabular_source
         tabular_dict_float = tabular_dict.copy()
         tabular_dict_float["timestamp"] = [ts + 0.1 for ts in tabular_dict["timestamp"]]
-        session.create_tabular_measurement(tabular_source, tabular_dict_float)
+        session.create_tabular_measurement(source_id, tabular_dict_float)
     assert exc.value.response.status_code == 422
 
 
 def test_tabular_measurements(session, tabular_source):
-    columns = tabular_df.columns.tolist()
+    source_id, tabular_dict = tabular_source
+    columns = list(tabular_dict.keys())
     columns.remove("timestamp")
-    session.create_tabular_measurement(tabular_source, tabular_dict)
+    tabular_df = pd.DataFrame(tabular_dict)
+    
+    # Create tabular measurement
+    session.create_tabular_measurement(source_id, tabular_dict)
 
     # create measurements again (409 ignored)
-    session.create_tabular_measurement(tabular_source, tabular_dict, exist_ok=True)
+    session.create_tabular_measurement(source_id, tabular_dict, exist_ok=True)
 
     # create measurements again (409 not ignored)
     with pytest.raises(HTTPError) as exc:
-        session.create_tabular_measurement(tabular_source, tabular_dict)
+        session.create_tabular_measurement(source_id, tabular_dict)
     assert exc.value.response.status_code == 409
 
+    # Validate read single measruement
     ts0 = tabular_dict["timestamp"][0]
-    meas = session.read_single_measurement(tabular_source, ts0)
+    meas = session.read_single_measurement(source_id, ts0)
     assert meas["meta"] == {}
     assert all(np.array(meas["data"]) == tabular_df.drop("timestamp", axis=1).iloc[0])
     assert meas["columns"] == columns
 
-    session.update_measurement(tabular_source, ts0, {"new": "meta"})
-    meas = session.read_single_measurement(tabular_source, ts0)
+    # Validate update measurement
+    session.update_measurement(source_id, ts0, {"new": "meta"})
+    meas = session.read_single_measurement(source_id, ts0)
     assert meas["meta"] == {"new": "meta"}
 
-    session.delete_measurement(tabular_source, ts0)
+    # Validate delete measurement
+    session.delete_measurement(source_id, ts0)
     with pytest.raises(HTTPError) as exc:
-        session.read_single_measurement(tabular_source, ts0)
+        session.read_single_measurement(source_id, ts0)
     assert exc.value.response.status_code == 404
 
 
 def test_list_tabular_measurements(session, tabular_source):
-    columns = tabular_df.columns.tolist()
+    source_id, tabular_dict = tabular_source
+    columns = list(tabular_dict.keys())
 
     ts_0 = tabular_dict["timestamp"][0]
     ts_1 = tabular_dict["timestamp"][1]
@@ -324,10 +304,10 @@ def test_list_tabular_measurements(session, tabular_source):
     }
 
     # Create all measurements
-    session.create_tabular_measurement(tabular_source, tabular_dict, meta)
+    session.create_tabular_measurement(source_id, tabular_dict, meta)
 
     # Retrieve data for a segment (1..n)
-    response = session.list_tabular_measurements(tabular_source, ts_1, ts_n)
+    response = session.list_tabular_measurements(source_id, ts_1, ts_n)
     assert all(
         tabular_dict[column][1:] == response["data"][column] for column in columns
     )
@@ -335,7 +315,7 @@ def test_list_tabular_measurements(session, tabular_source):
     assert response["meta"][f"{ts_1}"] == meta[f"{ts_1}"]
 
     # Retrieve entire data (0..n)
-    response = session.list_tabular_measurements(tabular_source, None, None)
+    response = session.list_tabular_measurements(source_id, None, None)
     assert all(tabular_dict[column] == response["data"][column] for column in columns)
     assert len(response["meta"].keys()) == 2
     assert response["meta"][f"{ts_0}"] == meta[f"{ts_0}"]
@@ -343,32 +323,33 @@ def test_list_tabular_measurements(session, tabular_source):
 
     # Retrieve data that is beyond the range of the dataset timestamps
     with pytest.raises(HTTPError) as exc:
-        session.list_tabular_measurements(tabular_source, ts_n + 1, ts_n + 2)
+        session.list_tabular_measurements(source_id, ts_n + 1, ts_n + 2)
     assert exc.value.response.status_code == 404
 
     # Call API with negative timestamp
     with pytest.raises(HTTPError) as exc:
-        session.list_tabular_measurements(tabular_source, -1)
+        session.list_tabular_measurements(source_id, -1)
     assert exc.value.response.status_code == 422
 
     # Call API with negative timestamp
     with pytest.raises(HTTPError) as exc:
-        session.list_tabular_measurements(tabular_source, None, -1)
+        session.list_tabular_measurements(source_id, None, -1)
     assert exc.value.response.status_code == 422
 
 
 def test_create_label(session, tabular_source_with_measurements):
+    source_id, tabular_dict = tabular_source_with_measurements
     timestamps = tabular_dict["timestamp"]
     label1 = {"label": "normal", "severity": 0, "notes": ""}
     label2 = {"label": "failure", "severity": 100, "notes": "This is really bad!"}
 
-    session.create_label(tabular_source_with_measurements, timestamps[0], **label1)
-    session.create_label(tabular_source_with_measurements, timestamps[1], **label2)
+    session.create_label(source_id, timestamps[0], **label1)
+    session.create_label(source_id, timestamps[1], **label2)
 
-    label1_response = session.get_label(tabular_source_with_measurements, timestamps[0])
-    label2_response = session.get_label(tabular_source_with_measurements, timestamps[1])
+    label1_response = session.get_label(source_id, timestamps[0])
+    label2_response = session.get_label(source_id, timestamps[1])
 
-    labels = session.list_labels(tabular_source_with_measurements)
+    labels = session.list_labels(source_id)
 
     # Remove timestamps
     for label in labels:
@@ -393,14 +374,15 @@ def test_create_label(session, tabular_source_with_measurements):
 
 
 def test_update_label(session, tabular_source_with_measurements):
+    source_id, tabular_dict = tabular_source_with_measurements
     timestamps = tabular_dict["timestamp"]
     label_pre = {"label": "failure", "severity": 100, "notes": "This is really bad!"}
-    session.create_label(tabular_source_with_measurements, timestamps[0], **label_pre)
+    session.create_label(source_id, timestamps[0], **label_pre)
 
     label_post = {"label": "normal", "severity": 0, "notes": "It wasn't so bad"}
-    session.update_label(tabular_source_with_measurements, timestamps[0], **label_post)
+    session.update_label(source_id, timestamps[0], **label_post)
 
-    label_response = session.get_label(tabular_source_with_measurements, timestamps[0])
+    label_response = session.get_label(source_id, timestamps[0])
 
     label_timestamp = label_response.pop("label_timestamp")
     dtdiff = datetime.utcnow() - datetime.strptime(label_timestamp, "%Y-%m-%d %H:%M:%S")
@@ -409,18 +391,19 @@ def test_update_label(session, tabular_source_with_measurements):
 
 
 def test_delete_label(session, tabular_source_with_measurements):
+    source_id, tabular_dict = tabular_source_with_measurements
     timestamps = tabular_dict["timestamp"]
     session.create_label(
-        tabular_source_with_measurements,
+        source_id,
         timestamps[0],
         "failure",
         100,
         "This is really bad!",
     )
 
-    session.delete_label(tabular_source_with_measurements, timestamps[0])
+    session.delete_label(source_id, timestamps[0])
     with pytest.raises(HTTPError) as exc:
-        session.get_label(tabular_source_with_measurements, timestamps[0])
+        session.get_label(source_id, timestamps[0])
         assert exc.value.response.status_code == 404
 
 

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -215,9 +215,7 @@ def test_sources_cru_existing(session):
     assert src["meta"] == meta
 
     # create_source again (409 ignored)
-    session.create_source(
-        source, meta=meta, channels=["acc"], exist_ok=True
-    )
+    session.create_source(source, meta=meta, channels=["acc"], exist_ok=True)
 
     # create_source again (409 not ignored)
     with pytest.raises(HTTPError):
@@ -258,7 +256,7 @@ def test_tabular_measurements(session, tabular_source):
     columns = list(tabular_dict.keys())
     columns.remove("timestamp")
     tabular_df = pd.DataFrame(tabular_dict)
-    
+
     # Create tabular measurement
     session.create_tabular_measurement(source_id, tabular_dict)
 


### PR DESCRIPTION
# Description

This PR attends to the following:
- refactors the code under the `tests` folder such that all fixtures that creates a source and corresponding measurements is in `conftest`
- adds 4 test cases to test the `selected_channels` and `selected_columns` arguments for the method `MVG.request_analysis`
- fixes a bug: Blacksheep at the backend doesn't allow `selected_channels` and `selected_columns` in the `params` dict, so passing them into the `params` dict from the frontend should not be allowed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update

## Checklist

- [x] I have added tests that prove that my fix/feature works
- [x] Linters pass locally and I have followed PEP8 code style
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
