### PR TITLE
Cancel pipeline run for old commits in PR

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+    group: ${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     black: 
         runs-on: [ ubuntu-latest ]


### PR DESCRIPTION
# Description

Currently, the pipeline runs for each commit to a PR. 
With the concurrency feature of GitHub Actions included, on a new commit to the same branch/PR, existing pipeline runs will be abrupted resulting in GitHub Actions time savings.

Fixes #118

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [ ] I have updated the MVG version
