### PR TITLE
Update all references of outdated filenames of examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Viking Analytics AB
+   Copyright 2022 Viking Analytics AB
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(REPO_ROOT.resolve()))
 # -- Project information -----------------------------------------------------
 
 project = "MultiViz Analytics Engine Library"
-copyright = "2021, Viking Analytics AB"
+copyright = "2022, Viking Analytics AB"
 author = "Viking Analytics AB"
 
 

--- a/docs/source/content/examples/1-brief_overview.ipynb
+++ b/docs/source/content/examples/1-brief_overview.ipynb
@@ -734,7 +734,7 @@
    "source": [
     "In this example, we will show how to request the KPIDemo and ModeId features to be applied to the previously defined SOURCE_ID.\n",
     "The BlackSheep feature is aimed to population analytics.\n",
-    "You can read about how to use it in the [\"Analysis and Results Visualization\"](analysis_visual.ipynb) example.\n",
+    "You can read about how to use it in the [\"Analysis and Results Visualization\"](6-analysis_visual.ipynb) example.\n",
     "\n",
     "We will begin with the 'KPIDemo' feature, which provides KPIs, such as RMS, for each vibration measurement.\n",
     "We proceed to request the analysis to the MVG service."

--- a/docs/source/content/examples/5-analysis_classes.ipynb
+++ b/docs/source/content/examples/5-analysis_classes.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "1. Installed mvg package\n",
     "2. A token for API access from Viking Analytics\n",
-    "3. The database needs to be populated with our example assets. This can be achieved by running the [\"Sources and Measurement\"](sources_and_measurements.ipynb) example."
+    "3. The database needs to be populated with our example assets. This can be achieved by running the [\"Sources and Measurement\"](2-sources_and_measurements.ipynb) example."
    ]
   },
   {

--- a/docs/source/content/examples/6-analysis_visual.ipynb
+++ b/docs/source/content/examples/6-analysis_visual.ipynb
@@ -11,7 +11,7 @@
     "In addition, it presents some examples of how to visualize the results available for the mode identification feature.\n",
     "\n",
     "In this example, we will describe how to access and manipulate the analysis results directly.\n",
-    "The [\"Analysis Classes\"](analysis_classes.ipynb) example provides a simplified and unified interface to access these results as a pandas dataframe, along with some basic visualization of the results.\n",
+    "The [\"Analysis Classes\"](5-analysis_classes.ipynb) example provides a simplified and unified interface to access these results as a pandas dataframe, along with some basic visualization of the results.\n",
     "\n",
     "## Preliminaries\n",
     "\n",
@@ -99,7 +99,7 @@
    "source": [
     "## Asset Analysis\n",
     "\n",
-    "In this example, we will use the sources uploaded by the [\"Sources and Measurement\"](sources_and_measurements.ipynb) example.\n",
+    "In this example, we will use the sources uploaded by the [\"Sources and Measurement\"](2-sources_and_measurements.ipynb) example.\n",
     "We start by looking if the sources are available in the database.\n",
     "At least, sources, \"u0001\" and \"u0005\", should appear as available."
    ]
@@ -612,7 +612,7 @@
     "\n",
     "These lists can be converted into a dataframe for ease of manipulation.\n",
     "In this example, we will show how to access the dictionary results information and convert it into a Pandas dataframe.\n",
-    "Please check the [\"Analysis Classes\"](analysis_classes.ipynb) example for directly getting a results Pandas dataframe.\n",
+    "Please check the [\"Analysis Classes\"](5-analysis_classes.ipynb) example for directly getting a results Pandas dataframe.\n",
     "In addition, the \"timestamp\" column is converted to a timestamp object in a column called \"Date\"."
    ]
   },
@@ -774,7 +774,7 @@
     "\n",
     "We pass all the lists to a dataframe for ease of manipulation.\n",
     "Similarly to the RMS feature, we will show how to access the dictionary results information and convert it into a Pandas dataframe.\n",
-    "Please check the [\"Analysis Classes\"](analysis_classes.ipynb) example for directly getting a results Pandas dataframe.\n",
+    "Please check the [\"Analysis Classes\"](5-analysis_classes.ipynb) example for directly getting a results Pandas dataframe.\n",
     "In addition, the \"timestamp\" column is converted to a timestamp object in a column called \"Date\"."
    ]
   },
@@ -1713,7 +1713,7 @@
     }
    },
    "source": [
-    "Please check the [\"Analysis Classes\"](analysis_classes.ipynb) example for some of the visualization options of the blacksheep results.\n"
+    "Please check the [\"Analysis Classes\"](5-analysis_classes.ipynb) example for some of the visualization options of the blacksheep results.\n"
    ]
   }
  ],

--- a/docs/source/content/examples/7-labeling.ipynb
+++ b/docs/source/content/examples/7-labeling.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "1. Installed `mvg` package\n",
     "2. A token for API access from Viking Analytics\n",
-    "3. The database needs to be populated with our example assets. This can be achieved by running the [\"Sources and Measurement\"](sources_and_measurements.ipynb) example."
+    "3. The database needs to be populated with our example assets. This can be achieved by running the [\"Sources and Measurement\"](2-sources_and_measurements.ipynb) example."
    ]
   },
   {

--- a/docs/source/content/features/general.md
+++ b/docs/source/content/features/general.md
@@ -5,7 +5,7 @@ vibration data. The documentation in the FEATURES section
 focuses mostly on description of
 the features, for detailed information on how to invoke the features
 via the API, consult the [API Reference](../api_reference/mvg.html) or
-the [Examples](../examples/analysis_visual.html).
+the [Examples](../examples/6-analysis_visual.html).
 
 ## How to use features via MVG
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,14 +11,14 @@
    :maxdepth: 2
    :caption: Examples
 
-   content/examples/brief_overview
-   content/examples/check_version
-   content/examples/error_handling
-   content/examples/sources_and_measurements
-   content/examples/analysis_visual
-   content/examples/analysis_classes
-   content/examples/tabular_example
-   content/examples/labeling
+   content/examples/1-brief_overview
+   content/examples/0-check_version
+   content/examples/4-error_handling
+   content/examples/2-sources_and_measurements
+   content/examples/6-analysis_visual
+   content/examples/5-analysis_classes
+   content/examples/3-tabular_example
+   content/examples/7-labeling
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
# Description

The sphnix doc files and the links in the notebooks were referring to the old filenames of the examples. This PR updates the filenames.

Fixes #133 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [x] Documentation Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [x] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [ ] I have updated the MVG version
