### PR TITLE
Use upgraded pygments package

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -84,6 +84,10 @@ jobs:
         name: "Validate examples in documentation"
         steps:
         -   uses: actions/checkout@v2
+        -   name: "Set up Python 3"
+            uses: actions/setup-python@v2
+            with: 
+                python-version: '3.x'
         -   name: "Run all examples"
             env:
                 TEST_TOKEN: ${{ secrets.TEST_TOKEN }}

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -55,7 +55,7 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.11.4")
+        self.mvg_version = self.parse_version("v0.11.5")
         self.tested_api_version = self.parse_version("v0.3.0")
 
         # Get API version


### PR DESCRIPTION
# Description
The `validate-examples` task was supposedly using python 3.8 environment and in this environment, the `sphinx` package seemed to be installing an older version of `Pygments` (as seen in the image below), whereas the other packages in `requirements_docs` needed `Pygments >= 2.6.1`. I guess this happens due to an incompatible version of `pip` and `sphinx` being used together.

![image](https://user-images.githubusercontent.com/5328735/153093218-00ca216d-33a1-4168-bafb-362e374ad06b.png)


After researching and trying out different options, realized that using the latest python environment (3.10.x) actually installs the latest version of `Pygments` package!

Fixes #135 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
