### PR TITLE
ci-checks workflow concurrency enabled only for PR runs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 concurrency:
-    group: ${{ github.ref }}
+    group: ${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description

ci-checks workflow concurrency enabled only for PR runs

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [ ] I have updated the MVG version
