### PR TITLE
Limit step run time in test-notebooks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -84,7 +84,7 @@ jobs:
         strategy:
             matrix:
               python-version: [3.6,3.7,3.8,3.9,"3.10"]
-        steps: 
+        steps:
         -   uses: actions/checkout@v2
         -   name: "Set up Python ${{ matrix.python-version }}"
             uses: actions/setup-python@v2
@@ -102,6 +102,7 @@ jobs:
                 username: vagrinder
                 password: ${{ secrets.VAGRINDER_GITHUB_PKG_TOKEN }}
         -   name: "Running tests with pytest"
+            timeout-minutes: 120
             env:
                 TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
             run: "python -m pytest --verbose tests/test_notebooks.py"


### PR DESCRIPTION
# Description

Failure to run step "Running tests with pytest" in 120 mins for a python version in the `strategy-matrix` will auto kill all in-progress runs for other python versions in the matrix.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [x] GitHub workflow Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [ ] I have updated the MVG version
