### PR TITLE
Mark tests not meant to be run for mvg-integration

### DIFF
--- a/tests/test_api_general.py
+++ b/tests/test_api_general.py
@@ -22,6 +22,7 @@ def test_say_hello(vibium):
 
 
 # Ensure tested version is the production version
+@pytest.mark.skipintegration
 def test_check_prod_version(vibium_prod):
     session = MVG(vibium_prod, "")
     assert session.api_version == session.tested_api_version
@@ -29,6 +30,7 @@ def test_check_prod_version(vibium_prod):
 
 # API        /
 # Test version handling
+@pytest.mark.skipintegration
 def test_check_version(vibium):
 
     # Get current API version for testing


### PR DESCRIPTION
# Description

Make use of pytest markers to mark test cases not to be run in the `mvg-integration` task in the backend CI/CD. I also wanted to mark an entire file (test_notebooks) with a specific marker, but it seems the imports section in the file is still executed which will result in import errors.

A benefit of this is, in the command line, we do not have to mention "not function1 and not function2" if we want to skip the tests named function1 and function2. Rather we could mark the test cases with a label "skiptest" and use the flag --skiptest in the pytest command

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [x] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [ ] CI/CD workflows Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [x] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [ ] I have updated the MVG version
