### PR TITLE
Retry mechanism for specific failed requests

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -85,7 +85,7 @@ jobs:
         -   name: "Running tests with pytest"
             env:
                 TEST_TOKEN: ${{ secrets.TEST_TOKEN }}
-            run: "python -m pytest --verbose tests/ --ignore=tests/test_notebooks.py"
+            run: "python -m pytest --durations=0 --verbose tests/ --ignore=tests/test_notebooks.py"
         -   name: Log out of Amazon ECR
             id: login-ecr
             if: always()

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,17 +1,12 @@
 [pylint]
 disable =
     R0904,
-    R0801,
-    no-self-argument,
-    no-name-in-module,
     too-few-public-methods,
     too-many-arguments,
     logging-fstring-interpolation,
-    fixme,
     missing-module-docstring,
     missing-function-docstring,
     missing-class-docstring,
     raise-missing-from,
-    unsubscriptable-object # TODO: Only required in python 3.9
 
 max-line-length = 88

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,5 @@
 [pylint]
-disable = 
-    W3101, # missing-timeout
+disable =
     R0904,
     R0801,
     no-self-argument,

--- a/mvg/http_client.py
+++ b/mvg/http_client.py
@@ -37,7 +37,7 @@ class HTTPClient:
         if not self.retries:
             self.retries = RequestRetry(
                 total=3,
-                status_forcelist=[502],
+                status_forcelist=[500, 502, 503, 504],
                 raise_on_status=False,
                 backoff_factor=0.5,
                 remove_headers_on_redirect=[],

--- a/mvg/http_client.py
+++ b/mvg/http_client.py
@@ -1,0 +1,74 @@
+import logging
+from requests import Session
+from requests.adapters import HTTPAdapter, Retry
+from mvg.exceptions import raise_for_status
+
+logger = logging.getLogger(__name__)
+
+
+class RequestRetry(Retry):
+    """
+    Retry with logging
+    """
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("history"):
+            request = kwargs.get("history")[-1]
+            logger.warning(
+                f"Retring request {request[1]} with status code {request[3]}"
+            )
+
+        super().__init__(*args, **kwargs)
+
+
+class HTTPClient:
+    def __init__(
+        self,
+        endpoint,
+        token,
+        retries=None,
+        timeout=120,
+    ):
+        self.endpoint = endpoint
+        self.token = token
+        self.timeout = timeout
+
+        self.retries = retries
+        if not self.retries:
+            self.retries = RequestRetry(
+                total=3,
+                status_forcelist=[502],
+                raise_on_status=False,
+                backoff_factor=0.5,
+                remove_headers_on_redirect=[],
+            )
+
+    def request(self, method, path, headers=None, do_not_raise=None, **kwargs):
+        response = None
+        with Session() as session:
+            session.mount("http://", HTTPAdapter(max_retries=self.retries))
+            session.mount("https://", HTTPAdapter(max_retries=self.retries))
+
+            _headers = {"Authorization": f"Bearer {self.token}"}
+            if headers:
+                _headers.update(headers)
+
+            response = session.request(
+                method=method,
+                url=self.endpoint + path,
+                headers=_headers,
+                timeout=self.timeout,
+                **kwargs,
+            )
+
+            if do_not_raise is None:
+                do_not_raise = []
+
+            if response.status_code in do_not_raise:
+                logger.warning(
+                    f"Ignoring error {response.status_code} - {response.text}"
+                )
+            else:
+                raise_for_status(response)
+
+        return response

--- a/mvg/http_client.py
+++ b/mvg/http_client.py
@@ -11,14 +11,29 @@ class RequestRetry(Retry):
     Retry with logging
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        total=3,
+        status_forcelist=frozenset([500, 502, 503, 504]),
+        raise_on_status=False,
+        backoff_factor=0.5,
+        remove_headers_on_redirect=frozenset(),
+        **kwargs,
+    ):
         if kwargs.get("history"):
             request = kwargs.get("history")[-1]
             logger.warning(
                 f"Retring request {request[1]} with status code {request[3]}"
             )
 
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            total=total,
+            status_forcelist=status_forcelist,
+            raise_on_status=raise_on_status,
+            backoff_factor=backoff_factor,
+            remove_headers_on_redirect=remove_headers_on_redirect,
+            **kwargs,
+        )
 
 
 class HTTPClient:
@@ -35,13 +50,7 @@ class HTTPClient:
 
         self.retries = retries
         if not self.retries:
-            self.retries = RequestRetry(
-                total=3,
-                status_forcelist=[500, 502, 503, 504],
-                raise_on_status=False,
-                backoff_factor=0.5,
-                remove_headers_on_redirect=[],
-            )
+            self.retries = RequestRetry()
 
     def request(self, method, path, headers=None, do_not_raise=None, **kwargs):
         response = None

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -17,10 +17,10 @@ from typing import Dict, List, Optional
 import pandas as pd
 import requests
 from requests.exceptions import RequestException
-
 import semver
 
-from mvg.exceptions import MVGConnectionError, raise_for_status
+from mvg.exceptions import MVGConnectionError
+from mvg.http_client import HTTPClient
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class MVGAPI:
         self.token = token
 
         self.mvg_version = self.parse_version("v0.13.1")
-        self.tested_api_version = self.parse_version("v0.4.6")
+        self.tested_api_version = self.parse_version("v0.4.7")
 
         # Get API version
         try:
@@ -94,22 +94,10 @@ class MVGAPI:
         -------
         Response from the API call
         """
-        headers = {"Authorization": f"Bearer {self.token}"}
-        response = requests.request(
-            method=method,
-            url=self.endpoint + path,
-            headers=headers,
-            **kwargs,
+        client = HTTPClient(self.endpoint, self.token)
+        response = client.request(
+            method=method, path=path, do_not_raise=do_not_raise, **kwargs
         )
-
-        if do_not_raise is None:
-            do_not_raise = []
-
-        if response.status_code in do_not_raise:
-            logger.info(f"Ignoring error {response.status_code} - {response.text}")
-        else:
-            raise_for_status(response)
-
         return response
 
     @staticmethod

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -70,7 +70,9 @@ class MVGAPI:
         self.api_version = self.parse_version(api_vstr)
         self.api_content = api_root["content"]
 
-    def _request(self, method, path, do_not_raise=None, **kwargs) -> requests.Response:
+    def _request(
+        self, method, path, do_not_raise=None, retries=None, **kwargs
+    ) -> requests.Response:
         """Helper function for removing duplicate code on API requests.
         Makes requests on self.endpoint with authorization header and
         validates the response by status code. Writes DEBUG logs on
@@ -87,6 +89,9 @@ class MVGAPI:
         do_not_raise : list
             List of error status codes to ignore. Defaults to [] if None
 
+        retries: RequestRetry
+            A RequestRetry object that defines the configuration for retry requests
+
         **kwargs : Any
             Keyword arguments to pass to requests.request
 
@@ -94,7 +99,7 @@ class MVGAPI:
         -------
         Response from the API call
         """
-        client = HTTPClient(self.endpoint, self.token)
+        client = HTTPClient(self.endpoint, self.token, retries)
         response = client.request(
             method=method, path=path, do_not_raise=do_not_raise, **kwargs
         )

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -56,7 +56,7 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.13.1")
+        self.mvg_version = self.parse_version("v0.13.2")
         self.tested_api_version = self.parse_version("v0.4.7")
 
         # Get API version

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ darglint
 pylint
 pytest
 pytest-docker
+pytest_localserver
 # for callback test server
 uvicorn==0.16.0
 fastapi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_configure():
     pytest.SOURCE_ID_WAVEFORM = uuid.uuid1().hex
     pytest.REF_DB_PATH = Path.cwd() / "tests" / "test_data" / "mini_charlie"
     pytest.SOURCE_ID_TABULAR = uuid.uuid1().hex
-    pytest.VALID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDY3Mjk4NzEsImV4cCI6MTk2MjM1MjYyMCwiY2xpZW50X2lkIjoidmFfdGhpbmdzYm9hcmQiLCJzaXRlX2lkIjoiZGVtbyJ9.APD54EHbHkldnAI9LVIYMVqFx4x5Zp2h9JU-EjxLyDSLjDWXG2z6nxfWNXb3WL30CjeZmIievjq0dqlMFNTHPntzX9kXm9xH7Ze2FbxAPVNbQIDn0YjJRSol1-mjKBfLHS80ildHtmF2jJS8MTvGV7scX7xYu3YyfGeRzpE12io"
+    pytest.VALID_TOKEN = os.environ["TEST_TOKEN"]
 
 
 def is_responsive(url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_configure():
     pytest.SOURCE_ID_WAVEFORM = uuid.uuid1().hex
     pytest.REF_DB_PATH = Path.cwd() / "tests" / "test_data" / "mini_charlie"
     pytest.SOURCE_ID_TABULAR = uuid.uuid1().hex
-    pytest.VALID_TOKEN = os.environ["TEST_TOKEN"]
+    pytest.VALID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDY3Mjk4NzEsImV4cCI6MTk2MjM1MjYyMCwiY2xpZW50X2lkIjoidmFfdGhpbmdzYm9hcmQiLCJzaXRlX2lkIjoiZGVtbyJ9.APD54EHbHkldnAI9LVIYMVqFx4x5Zp2h9JU-EjxLyDSLjDWXG2z6nxfWNXb3WL30CjeZmIievjq0dqlMFNTHPntzX9kXm9xH7Ze2FbxAPVNbQIDn0YjJRSol1-mjKBfLHS80ildHtmF2jJS8MTvGV7scX7xYu3YyfGeRzpE12io"
 
 
 def is_responsive(url):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,80 @@
+from mvg.exceptions import MVGAPIError
+from mvg.http_client import HTTPClient, RequestRetry
+
+from pytest_localserver import http
+import pytest
+
+
+@pytest.fixture
+def httpserver(request):
+    server = http.ContentServer()
+    server.start()
+    request.addfinalizer(server.stop)
+    yield server
+
+
+def test_retry_default(httpserver):
+    client = HTTPClient(endpoint=httpserver.url, token="")
+    retries = client.retries.total
+    status_forcelist = client.retries.status_forcelist
+    status_code = status_forcelist[0]
+
+    # Ask the server to return content with the provided status code
+    httpserver.serve_content({}, code=status_code)
+    with pytest.raises(MVGAPIError) as excinfo:
+        client.request("get", "")
+
+    assert excinfo.value.response.status_code == status_code
+    assert len(httpserver.requests) == retries + 1
+
+
+def test_retry_custom(httpserver):
+    # Define retry for status code 402
+    status_code = 402
+    retries_obj = RequestRetry(
+        total=3,
+        status_forcelist=[status_code],
+        raise_on_status=False,
+        backoff_factor=0.5,
+        remove_headers_on_redirect=[],
+    )
+    client = HTTPClient(endpoint=httpserver.url, token="", retries=retries_obj)
+    retries = client.retries.total
+
+    httpserver.serve_content({}, code=status_code)
+    with pytest.raises(MVGAPIError) as exc:
+        client.request("get", "")
+
+    assert exc.value.response.status_code == status_code
+    assert len(httpserver.requests) == retries + 1
+
+
+def test_ignore_409(httpserver):
+    # Define retry for status code 402
+    client = HTTPClient(endpoint=httpserver.url, token="")
+    status_code = 409
+
+    httpserver.serve_content({}, code=status_code)
+    client.request("get", "", do_not_raise=[status_code])
+    assert len(httpserver.requests) == 1
+
+
+def test_do_not_ignore_409(httpserver):
+    # Define retry for status code 402
+    client = HTTPClient(endpoint=httpserver.url, token="")
+    status_code = 409
+
+    httpserver.serve_content({}, code=status_code)
+    with pytest.raises(MVGAPIError) as exc:
+        client.request("get", "", do_not_raise=[])
+    assert len(httpserver.requests) == 1
+
+
+def test_no_retry(httpserver):
+    client = HTTPClient(endpoint=httpserver.url, token="")
+    # Successful request is assumed to be never retried
+    status_code = 200
+
+    httpserver.serve_content({}, code=status_code)
+    client.request("get", "")
+    assert len(httpserver.requests) == 1

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -17,7 +17,7 @@ def test_retry_default(httpserver):
     client = HTTPClient(endpoint=httpserver.url, token="")
     retries = client.retries.total
     status_forcelist = client.retries.status_forcelist
-    status_code = status_forcelist[0]
+    status_code = next(iter(status_forcelist))
 
     # Ask the server to return content with the provided status code
     httpserver.serve_content({}, code=status_code)
@@ -50,22 +50,22 @@ def test_retry_custom(httpserver):
 
 
 def test_ignore_409(httpserver):
-    # Define retry for status code 402
     client = HTTPClient(endpoint=httpserver.url, token="")
     status_code = 409
 
     httpserver.serve_content({}, code=status_code)
+    # Does not raise 409
     client.request("get", "", do_not_raise=[status_code])
     assert len(httpserver.requests) == 1
 
 
 def test_do_not_ignore_409(httpserver):
-    # Define retry for status code 402
     client = HTTPClient(endpoint=httpserver.url, token="")
     status_code = 409
 
     httpserver.serve_content({}, code=status_code)
-    with pytest.raises(MVGAPIError) as exc:
+    # Raises 409
+    with pytest.raises(MVGAPIError) as _:
         client.request("get", "", do_not_raise=[])
     assert len(httpserver.requests) == 1
 


### PR DESCRIPTION
# Description

The exception `502 Bad Gateway` is quite a common exception after we have moved the cloud infrastructure to the AWS. The error is probably due to the Load balancer being unreachable or busy. In such cases, it is a good idea to retry the request. The code retries the request thrice before returning a response or an exception.

New dependencies: (Added to requirements_dev.txt)
- `pytest_localserver`

Fixes #167 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [x] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [ ] CI/CD workflows Update

## Checklist

- [x] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [x] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
