### PR TITLE
Get information about an analysis result

### DIFF
--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -61,8 +61,8 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.14.4")
-        self.tested_api_version = self.parse_version("v0.5.3")
+        self.mvg_version = self.parse_version("v0.14.5")
+        self.tested_api_version = self.parse_version("v0.5.6")
 
         # Get API version
         try:
@@ -445,7 +445,7 @@ class MVGAPI:
         """
 
         logger.info("endpoint %s", self.endpoint)
-        logger.info("creating measurement from source id=%s", sid)
+        logger.info("creating measurement for source id=%s", sid)
         logger.info("  duration:  %s", duration)
         logger.info("  timestamp: %s", timestamp)
         logger.info("  meta data: %s", meta)
@@ -505,7 +505,7 @@ class MVGAPI:
         """
 
         logger.info("endpoint %s", self.endpoint)
-        logger.info("creating tabular measurement from source id=%s", sid)
+        logger.info("creating tabular measurement for source id=%s", sid)
 
         do_not_raise = []
         if exist_ok:

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -1044,6 +1044,32 @@ class MVGAPI:
 
         return response.json()["request_status"]
 
+    def get_analysis_info(self, request_id: str) -> dict:
+        """Retrieves info of an analysis request.
+
+        The info of an analysis request includes the current status and the
+        status history of the analysis where the status history is a list of
+        statuses logged for the analysis. The info also contains an overview
+        of the measurements used by the analysis.
+
+        Parameters
+        ----------
+        request_id : str
+            request_id (analysis identifier)
+
+        Returns
+        -------
+        dict
+            a dictionary with the analysis info.
+
+        """
+        logger.info("endpoint %s", self.endpoint)
+        logger.info("get analysis info with request_id=%s", request_id)
+
+        response = self._request("get", f"/analyses/requests/{request_id}")
+
+        return response.json()
+
     def get_analysis_results(
         self,
         request_id: str,

--- a/tests/test_api_analyses.py
+++ b/tests/test_api_analyses.py
@@ -259,3 +259,19 @@ def test_get_analysis_results_kpidemo_paginated(
 
     # Delete analysis
     session.delete_analysis(request_id)
+
+
+def test_get_analysis_info(session: MVG, waveform_source_multiaxial_001):
+    sid, _ = waveform_source_multiaxial_001
+    request = session.request_analysis(sid, "KPIDemo")
+    request_id = request["request_id"]
+
+    analysis_info = session.get_analysis_info(request_id)
+    assert isinstance(analysis_info, dict)
+    assert analysis_info["request_status"] in ["queued", "running"]
+    assert analysis_info["request_id"] == request_id
+
+    session.wait_for_analyses([request_id])
+
+    analysis_info = session.get_analysis_info(request_id)
+    assert analysis_info["request_status"] == "successful"

--- a/tests/test_api_sources.py
+++ b/tests/test_api_sources.py
@@ -396,15 +396,15 @@ def test_create_label(session, tabular_source_with_measurements):
     }
 
     label1_timestamp = label1_response.pop("label_timestamp")
-    dtdiff1 = datetime.utcnow() - datetime.strptime(
-        label1_timestamp, "%Y-%m-%d %H:%M:%S"
+    dtdiff1 = datetime.now().astimezone() - datetime.strptime(
+        label1_timestamp, "%Y-%m-%d %H:%M:%S%z"
     )
     assert label1_response == label1
     assert dtdiff1 < timedelta(minutes=1)
 
     label2_timestamp = label2_response.pop("label_timestamp")
-    dtdiff2 = datetime.utcnow() - datetime.strptime(
-        label2_timestamp, "%Y-%m-%d %H:%M:%S"
+    dtdiff2 = datetime.now().astimezone() - datetime.strptime(
+        label2_timestamp, "%Y-%m-%d %H:%M:%S%z"
     )
     assert label2_response == label2
     assert dtdiff2 < timedelta(minutes=1)
@@ -422,7 +422,9 @@ def test_update_label(session, tabular_source_with_measurements):
     label_response = session.get_label(source_id, timestamps[0])
 
     label_timestamp = label_response.pop("label_timestamp")
-    dtdiff = datetime.utcnow() - datetime.strptime(label_timestamp, "%Y-%m-%d %H:%M:%S")
+    dtdiff = datetime.now().astimezone() - datetime.strptime(
+        label_timestamp, "%Y-%m-%d %H:%M:%S%z"
+    )
     assert label_response == label_post
     assert dtdiff < timedelta(minutes=1)
 


### PR DESCRIPTION
# Description
- New method in MVG to retrieve the info of an analysis request
- PR https://github.com/vikinganalytics/vibium-cloud/pull/719 in the backend made updates to the date format of `created_at` to include the timezone. This affected some of the tests related to labels in MVG. A fix for these tests is included in this PR.

New dependencies: None
Fixes #201

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [x] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [ ] CI/CD workflows Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [x] Linters pass locally and I have followed PEP8 code style
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [x] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
