### PR TITLE
Fixes for paginated measurements requests

### DIFF
--- a/mvg/utils/response_processing.py
+++ b/mvg/utils/response_processing.py
@@ -77,7 +77,7 @@ def get_paginated_items(request: Callable, url: str, params: Dict) -> Dict:
     total_items_num = response["total"]
     request_limit = response["limit"]
 
-    offset = params.get("offset", 0)
+    offset = params.get("offset", response["offset"])
     limit = params.get("limit", total_items_num)
 
     # The items count we expect to receive given the pagination params

--- a/mvg/utils/response_processing.py
+++ b/mvg/utils/response_processing.py
@@ -3,11 +3,42 @@ This module contains helper functions for manipulating the response from endpoin
 """
 
 from enum import Enum
-from typing import Dict, Callable
+from typing import Callable, Dict
 
 from pydantic import conlist
 
 FrequencyRange = conlist(float, min_items=2, max_items=2)
+
+
+def clamp(value, minimum, maximum):
+    """
+    Clamps a value within a specified range.
+
+    Parameters
+    ----------
+    value : float|int
+        The value to be clamped.
+    minimum : float|int
+        The minimum value of the range.
+    maximum : float|int
+        The maximum value of the range.
+
+    Returns
+    -------
+    float or int: The clamped value,
+    which is guaranteed to be within the range [minimum, maximum].
+
+    Example
+    -------
+        >>> clamp(10, 0, 5)
+        5
+        >>> clamp(3, 0, 5)
+        3
+        >>> clamp(-1, 0, 5)
+        0
+    """
+
+    return max(minimum, min(value, maximum))
 
 
 class SortOrder(Enum):
@@ -40,25 +71,33 @@ def get_paginated_items(request: Callable, url: str, params: Dict) -> Dict:
         - "items": list of int, representing timestamps.
         - "total": int, representing total number of items.
     """
-    if "limit" in params or "offset" in params:
+    response = request("get", url, params=params)
+    response = response.json()
+    items = response["items"]
+    total_items_num = response["total"]
+    request_limit = response["limit"]
+
+    offset = params.get("offset", 0)
+    limit = params.get("limit", total_items_num)
+
+    # The items count we expect to receive given the pagination params
+    expected_num = clamp(limit, 0, total_items_num - offset)
+
+    # The items count we didn't receive due to request max items limit
+    missing_num = expected_num - len(items)
+
+    # How many additional requests to fetch the data
+    num_reqs = (missing_num - 1) // request_limit + 1
+
+    for _ in range(0, num_reqs):
+        if "limit" in params:
+            params["limit"] -= request_limit
+        offset += request_limit
+        params["offset"] = offset
         response = request("get", url, params=params)
-        response = response.json()
-        all_items = response["items"]
-        num_items = response["total"]
-    else:
-        # List all by default if pagination is not requested
-        response = request("get", url, params=params)
-        resp_first = response.json()
-        all_items = resp_first["items"]
-        num_items = resp_first["total"]
-        limit = resp_first["limit"]
-        num_reqs = (num_items - 1) // limit
-        for idx in range(1, num_reqs + 1):
-            offset = idx * limit
-            params["offset"] = offset
-            response = request("get", url, params=params)
-            all_items += response.json()["items"]
-    return {"items": all_items, "total": num_items}
+        items += response.json()["items"]
+
+    return {"items": items, "total": total_items_num}
 
 
 def get_paginated_analysis_results(request: Callable, url: str, params: Dict) -> Dict:

--- a/mvg/utils/response_processing.py
+++ b/mvg/utils/response_processing.py
@@ -97,7 +97,7 @@ def get_paginated_items(request: Callable, url: str, params: Dict) -> Dict:
         response = request("get", url, params=params)
         items += response.json()["items"]
 
-    return {"items": items, "total": total_items_num}
+    return {"items": items, "total": total_items_num, "limit": request_limit}
 
 
 def get_paginated_analysis_results(request: Callable, url: str, params: Dict) -> Dict:


### PR DESCRIPTION
# Description

Paginated requests `list_tabular_measurements` and `list_measurements` did not take into account the `max_measurements_pagination_limit` and `max_timestamps_pagination_limit` config parameters from vibium-cloud.

Fixes # (potential issues that are fixed by this PR)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [ ] CI/CD workflows Update

## Checklist

- [x] I have added tests that prove that my fix/feature works
- [x] Linters pass locally and I have followed PEP8 code style
- [x] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [x] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
