### PR TITLE
Add custom user-agent header to identify MVG

### DIFF
--- a/mvg/http_client.py
+++ b/mvg/http_client.py
@@ -41,12 +41,14 @@ class HTTPClient:
         self,
         endpoint,
         token,
+        mvg_version=None,
         retries=None,
         timeout=120,
     ):
         self.endpoint = endpoint
         self.token = token
         self.timeout = timeout
+        self.mvg_version = mvg_version
 
         self.retries = retries
         if not self.retries:
@@ -58,7 +60,10 @@ class HTTPClient:
             session.mount("http://", HTTPAdapter(max_retries=self.retries))
             session.mount("https://", HTTPAdapter(max_retries=self.retries))
 
-            _headers = {"Authorization": f"Bearer {self.token}"}
+            _headers = {
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": f"mvg/{self.mvg_version}",
+            }
             if headers:
                 _headers.update(headers)
 

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -63,8 +63,8 @@ class MVGAPI:
         self.endpoint = endpoint
         self.token = token
 
-        self.mvg_version = self.parse_version("v0.14.10")
-        self.tested_api_version = self.parse_version("v0.9.3")
+        self.mvg_version = self.parse_version("v0.14.11")
+        self.tested_api_version = self.parse_version("v0.9.6")
 
         # Get API version
         try:

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -64,7 +64,7 @@ class MVGAPI:
         self.token = token
 
         self.mvg_version = self.parse_version("v0.14.11")
-        self.tested_api_version = self.parse_version("v0.9.6")
+        self.tested_api_version = self.parse_version("v0.9.7")
 
         # Get API version
         try:

--- a/mvg/mvg.py
+++ b/mvg/mvg.py
@@ -106,7 +106,7 @@ class MVGAPI:
         -------
         Response from the API call
         """
-        client = HTTPClient(self.endpoint, self.token, retries)
+        client = HTTPClient(self.endpoint, self.token, self.mvg_version, retries)
         response = client.request(
             method=method, path=path, do_not_raise=do_not_raise, **kwargs
         )


### PR DESCRIPTION
# Description

Right now it is hard to identify MVG usage since there is User-Agent header specified. This PR fixes this. Please read more in the issue desciption.

Fixes #218 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue -> bump patch)
- [ ] New feature (non-breaking change which adds functionality -> bump minor version)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected -> bump major version)
- [ ] Documentation Update
- [ ] CI/CD workflows Update

## Checklist

- [ ] I have added tests that prove that my fix/feature works
- [ ] Linters pass locally and I have followed PEP8 code style
- [ ] New and existing tests pass locally
- [ ] I have updated the documentation if needed
- [ ] I have commented hard-to-understand areas in the code

## Requirements

- [x] I have updated the MVG version
